### PR TITLE
Double maxRetries to allow more retries

### DIFF
--- a/ecs-init/docker/docker.go
+++ b/ecs-init/docker/docker.go
@@ -70,7 +70,7 @@ const (
 	backoffMultiple = 2
 	// maxRetries specifies the maximum number of retries for ping to return
 	// a successful response from the docker socket
-	maxRetries = 5
+	maxRetries = 10
 	// CapNetAdmin to start agent with NET_ADMIN capability
 	// For more information on capabilities, please read this manpage:
 	// http://man7.org/linux/man-pages/man7/capabilities.7.html


### PR DESCRIPTION
### Summary
Doubles the maxRetries const to allow more retries if docker is unavailable


### Implementation details


### Testing
Not tested

New tests cover the changes: no

### Description for the changelog
Increase maxRetries to allow additional retries if docker is unavailable


### Licensing
This contribution is under the terms of the Apache 2.0 License: yes
